### PR TITLE
[FIX] 54 - false negative ValidationError

### DIFF
--- a/recipes/tests.py
+++ b/recipes/tests.py
@@ -93,8 +93,8 @@ class RecipeTestCase(TestCase):
 
     def test_unit_measure_validation_error(self):
         invalid_units = ['nada', 'asdfadsf']
-        with self.assertRaises(ValidationError):
-            for unit in invalid_units:
+        for unit in invalid_units:
+            with self.assertRaises(ValidationError):
                 ingredient = RecipeIngredient(
                     name='New',
                     quantity=10,


### PR DESCRIPTION
When "self.assertRaises(ValidationError)" is outside of a loop it does not raises error when valid units are tested, because it already raised one for invalid unit. Putting it inside of a loop fixes this false negative.